### PR TITLE
Themes: Pass themePackageName to createApplicationContext()

### DIFF
--- a/core/java/android/widget/RemoteViews.java
+++ b/core/java/android/widget/RemoteViews.java
@@ -2602,7 +2602,7 @@ public class RemoteViews implements Parcelable, Filter {
                 return context;
             }
             try {
-                return context.createApplicationContext(mApplication,
+                return context.createApplicationContext(mApplication, themePackageName,
                         Context.CONTEXT_RESTRICTED);
             } catch (NameNotFoundException e) {
                 Log.e(LOG_TAG, "Package name " + mApplication.packageName + " not found");


### PR DESCRIPTION
It would probably help if we actually made use of themePackageName
when getting a context for the resources used to inflate the remote
views.

Change-Id: I8782311715ec243486f96f04d019e0df844a337b